### PR TITLE
[fix] Dynamically updated url

### DIFF
--- a/client/components/Virtualize.tsx
+++ b/client/components/Virtualize.tsx
@@ -160,6 +160,7 @@ const ListboxComponent = React.forwardRef<
       onChange={(e, onChangeValue) => {
         if (onChangeValue !== null) {
           setValue(onChangeValue as DigestUser);
+          window.history.pushState({ id:"100" }, "Page", `/${onChangeValue.sciper}`)
           stateProps.handleOneLastResult(onChangeValue as DigestUser);
         }
       }}


### PR DESCRIPTION
`/sciper` was added only when the research was unique

Now, when clicking in the Autocomplete for the person we want, it also updates the URL.

close #37 