### PR TITLE
[fix] undefined undefined

### DIFF
--- a/client/components/Virtualize.tsx
+++ b/client/components/Virtualize.tsx
@@ -156,9 +156,9 @@ const ListboxComponent = React.forwardRef<
       filterOptions={(options, { inputValue }) =>
         filterOptions(options, inputValue)
       }
-      getOptionLabel={(x) => (x === "" ? "" : x.first_name + " " + x.last_name)}
+      getOptionLabel={(x) => (x.first_name == undefined ? x : x.first_name + " " + x.last_name)}
       onChange={(e, onChangeValue) => {
-        if (onChangeValue !== null) {
+        if (onChangeValue !== null && onChangeValue.sciper) {
           setValue(onChangeValue as DigestUser);
           window.history.pushState({ id:"100" }, "Page", `/${onChangeValue.sciper}`)
           stateProps.handleOneLastResult(onChangeValue as DigestUser);


### PR DESCRIPTION
When searching for someone that does not exists and pressing `enter`.
It showed `undefined undefined` everywhere on the page.

It's now fixed. Close #40 