### PR TITLE
[fix] `null` default searching

### DIFF
--- a/client/components/SearchBar.tsx
+++ b/client/components/SearchBar.tsx
@@ -9,7 +9,7 @@ function SearchBar(props:{handleOneLastResult: Function, sciper: string | undefi
     const [stateProps, setStateProps] = React.useState(props)
 
     React.useEffect(() => {
-        getUsers(stateProps.sciper)
+        stateProps.sciper && getUsers(stateProps.sciper)
     }, [])
 
     function getUsers(inputValue) {


### PR DESCRIPTION
When loading the page, it displayed some results even when nothing was in the search bar. It was because it searched like when there is a sciper in the URL, even there is not. So it searched with `null`.

Not really refactored all the search as you type, need to be paused a bit for the moment.