### PR TITLE
[fix] AdminsIT

### DIFF
--- a/client/components/Unit.tsx
+++ b/client/components/Unit.tsx
@@ -16,19 +16,11 @@ function Unit(props:{show?: boolean, infos: UnitInfos, user: DigestUser}) {
       } else {
         setAdminsIT([]);
         if(res.authorizations) {
-          const adminResArray = [];
-          res.authorizations.map(auth => {
-            Meteor.call('getUser.sciper', auth.persid, function(err, adminRes) {
-              if(err) {
-                console.log(err)
-              } else {
-                adminResArray.push(adminRes);
-                if (adminResArray.length === res.authorizations.length) {
-                  setAdminsIT(adminResArray);
-                }
-              }
-            })
+          let allAdminsIT = [];
+          res.authorizations.map(role => {
+            allAdminsIT.push(role.person);
           })
+          setAdminsIT(allAdminsIT)
         }
       }
     })

--- a/imports/api/apiMethod.ts
+++ b/imports/api/apiMethod.ts
@@ -50,7 +50,7 @@ Meteor.methods({
     },
     'getAdminsIT.unit': async function(unitid) {
       const auth = Buffer.from(`${settings.api.username}:${settings.api.password}`).toString("base64");
-      return fetch(encodeURI(`https://api.epfl.ch/v1/authorizations?resid=${unitid}&authid=adminit&type=role`), {
+      return fetch(encodeURI(`https://api-preprod.epfl.ch/v1/authorizations?resid=${unitid}&authid=adminit&type=role&alldata=1`), {
         method: "GET",
         headers: {
           "Content-type": "application/json",


### PR DESCRIPTION
AdminsIT are now fetched in one API request only.

We use `api-preprod.epfl.ch` until they deploy the `email` property in production.

close #93 