### PR TITLE
[fix] Own email address attribute

### DIFF
--- a/client/components/UserDetails.tsx
+++ b/client/components/UserDetails.tsx
@@ -158,7 +158,12 @@ function UserDetails(props:{user:DigestUser}) {
         if(err) {
           console.log(err)
         } else {
-          setOwnEmailAddrAuth(res.authorizations.length > 0);
+          if(res.authorizations.length > 0) {
+            const filteredResAuth = res.authorizations.filter((e) => e.status == 'active')
+            setOwnEmailAddrAuth(filteredResAuth.length > 0);
+          } else {
+            setOwnEmailAddrAuth(false);
+          }
         }
       })
     }, [props.user.id])


### PR DESCRIPTION
It wasn't enough to just check the length of the Array returned by the API. It was necessary to also check if the authorization's attribute `status` was set to `active`.

So, if at least one of the authorization(s) returned by the API has the status `active`, it means that the user has the right to have an email address.