### PR TITLE
[fix] `s/EPFL/INTRANET` for AD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.11 (2025-06-13)
+* Correct AD login handle (`INTRANET\username`)
+
+[...]
+lot of missing stuff
+[...]
+
 # 1.1.1 (2023-11-15)
 * Script to log special users
 * CHANGELOG.md file

--- a/client/components/UserDetails.tsx
+++ b/client/components/UserDetails.tsx
@@ -364,7 +364,7 @@ function UserDetails(props:{user:DigestUser}) {
                 <>
                   <ul>
                     {adData.userPrincipalName && (
-                      <li><strong>Domaine\login</strong> : {`${adData.userPrincipalName?.split('@')[1].split('.')[0].toUpperCase()}\\${adData.sAMAccountName}`}</li>
+                      <li><strong>Domaine\login</strong> : INTRANET\{`${adData.sAMAccountName}`}</li>
                     )}
                     <li><strong>Status du compte</strong> : {
                       adData.userAccountControl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react.starterkit",
-  "version": "1.2.0",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react.starterkit",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As mentioned in [INC0722026](https://go.epfl.ch/INC0722026) (Thanks Mathilde R), the AD login is `INTRANET\username` not `EPFL\username` as it was done in idp-exop.